### PR TITLE
s4-common: update WCNSS_qcom_cfg.ini

### DIFF
--- a/s4-common/proprietary/etc/firmware/wlan/prima/WCNSS_qcom_cfg.ini
+++ b/s4-common/proprietary/etc/firmware/wlan/prima/WCNSS_qcom_cfg.ini
@@ -155,9 +155,12 @@ BtAmpPreferredChannel=0
 #Preferred band (both or 2.4 only or 5 only)
 BandCapability=0
 
+# Enable 5G HT-40
+gChannelBondingMode5GHz=1
+
 #Beacon Early Termination (1 = enable the BET feature, 0 = disable)
-enableBeaconEarlyTermination=0
-beaconEarlyTerminationWakeInterval=3
+enableBeaconEarlyTermination=1
+beaconEarlyTerminationWakeInterval=10
 
 #Bluetooth Alternate Mac Phy (1 = enable the BT AMP feature, 0 = disable)
 gEnableBtAmp=0
@@ -180,8 +183,20 @@ gEnableBypass11d=1
 #If set to 0, will not scan DFS channels
 gEnableDFSChnlScan=1
 
+# Data Inactivity Timeout when in powersave (in ms)
+gDataInactivityTimeout=200
+
+# For RF performance: 0 for OLPC, 1 for CLPC and SCPC
+gEnableCloseLoop=1
+
+# Enable Dynamic DTIM
+gEnableDynamicDTIM=3
+
 # Enable logp/SSR
 gEnableLogp=1
+
+# Cache scan result count
+gScanResultAgeCount=1
 
 # Enable Automatic Tx Power control
 gEnableAutomaticTxPowerControl=1


### PR DESCRIPTION
- Enable 5GHz channel bonding
- Support early beacon termination, allowing radio to be turned off
  after TIM IE to save power
- Specify longer data inactivity timeout when in power save
- Use CLPC/SCPC
- Small cache for scan results

Change-Id: I427de4c4e5fa54c8f5914d262b4ab3ba96c0bc26
